### PR TITLE
feat: add light and dark theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,10 +5,32 @@
   font-family: "Helvetica", sans-serif; /* or futura */
 }
 
+:root {
+  --background: #ffffff;
+  --surface: #f4f4f9;
+  --text: #03045E;
+  --nav-background: #e3f2fd;
+  --icon-invert: 0;
+}
+
+body.light {
+  background-color: var(--surface);
+  color: var(--text);
+}
+
+body.dark {
+  --background: #03045E;
+  --surface: #001845;
+  --text: #ffffff;
+  --nav-background: #03045E;
+  --icon-invert: 1;
+  background-color: var(--surface);
+  color: var(--text);
+}
+
 html, body {
   height: 100%;
   margin: 0;
-  background-color: #03045E;
   /* overscroll-behavior-y: none; */
 }
 
@@ -22,7 +44,7 @@ html, body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  background-color: #ffffff;
+  background-color: var(--background);
 }
 
 .home,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,9 +16,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body className="light">
         <div className="root">
-          {/* <ScrollToTop /> */}    
+          {/* <ScrollToTop /> */}
           <Navbar />
             <div className="content">
               {children}

--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -1,11 +1,11 @@
-.footer_container {
-  background-color: #03045E;
-  padding: 1rem 0 2rem 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-}
+  .footer_container {
+    background-color: var(--nav-background);
+    padding: 1rem 0 2rem 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
 
 .social_media_wrapper {
   display: flex;
@@ -25,11 +25,11 @@
   transform: scale(1.1);
 }
 
-.social_icon_link {
-  color: #fff;
-  font-size: 25px;
-  padding: 30px;
-}
+  .social_icon_link {
+    color: var(--text);
+    font-size: 25px;
+    padding: 30px;
+  }
 
 .contact_us_wrapper {
   display: flex;
@@ -39,22 +39,22 @@
   margin-bottom: 12px;
 }
 
-.contact_us {
-  font-size: 20px;
-  color: #fff;
-  margin-right: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-}
-.nonprofitStatement {
-  font-size: 14px;
-  color: #fff;
-  text-align: center;
-  padding: 0 60px;
-  margin-top: 0px;
-  margin-bottom: 15px;
-}
+  .contact_us {
+    font-size: 20px;
+    color: var(--text);
+    margin-right: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .nonprofitStatement {
+    font-size: 14px;
+    color: var(--text);
+    text-align: center;
+    padding: 0 60px;
+    margin-top: 0px;
+    margin-bottom: 15px;
+  }
 
 .contact_us h4 {
   margin-bottom: 5px;
@@ -70,10 +70,10 @@
   margin-bottom: 18px;
 }
 
-.deadboltsEmail a {
-  color: #fff;
-  text-decoration: none;
-}
+  .deadboltsEmail a {
+    color: var(--text);
+    text-decoration: none;
+  }
 
 .contact_us iframe {
   margin-top: 10px;

--- a/src/components/navbar/navbar.module.css
+++ b/src/components/navbar/navbar.module.css
@@ -1,5 +1,6 @@
+
 .navbar {
-  background: linear-gradient(180deg, rgb(3, 4, 94) 0%, rgb(3, 4, 94) 100%);
+  background: var(--nav-background);
   height: 80px;
   display: flex;
   justify-content: center;
@@ -18,17 +19,17 @@
   max-width: 1500px;
 }
 
-.navbar_logo {
-  color: #fff;
-  justify-self: start;
-  margin-left: 5px;
-  cursor: pointer;
-  text-decoration: none;
-  font-size: 2rem;
-  display: flex;
-  align-items: center;
-  white-space: nowrap;
-}
+  .navbar_logo {
+    color: var(--text);
+    justify-self: start;
+    margin-left: 5px;
+    cursor: pointer;
+    text-decoration: none;
+    font-size: 2rem;
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+  }
 
 .navbar_img {
   width: 50px;
@@ -57,45 +58,54 @@
   height: 85px;
 }
 
-.nav_links {
-  color: #fff;
-  display: flex;
-  align-items: center;
-  text-decoration: none;
-  padding: 0.5rem 0.75rem;
-  height: 100%;
-}
+  .nav_links {
+    color: var(--text);
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    padding: 0.5rem 0.75rem;
+    height: 100%;
+  }
 
-.nav_links:hover {
-  border-bottom: 4px solid #fff;
-  transition: all 0.2s ease-out;
-}
+  .nav_links:hover {
+    border-bottom: 4px solid var(--text);
+    transition: all 0.2s ease-out;
+  }
 
-.fa_bars {
-  color: #fff;
-}
+  .fa_bars {
+    color: var(--text);
+  }
 
 .nav_links_mobile {
   display: none;
 }
 
-.menu_icon {
-  display: none;
-}
-
-.menu_icon_img {
-  filter: invert(1); 
-  transition: transform 0.3s ease;
-}
-
-.menu_icon_img:hover {
-  transform: scale(1.1);
-}
-
-@media screen and (max-width: 960px) {
-  .NavbarItems {
-    position: relative;
+  .menu_icon {
+    display: none;
   }
+
+  .menu_icon_img {
+    filter: invert(var(--icon-invert));
+    transition: transform 0.3s ease;
+  }
+
+  .menu_icon_img:hover {
+    transform: scale(1.1);
+  }
+
+  .theme_toggle {
+    margin-left: 1rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text);
+    font-size: 1.5rem;
+  }
+
+  @media screen and (max-width: 960px) {
+    .NavbarItems {
+      position: relative;
+    }
 
   .nav_menu {
     display: flex;
@@ -111,13 +121,13 @@
     justify-content: flex-start;
   }
 
-  .nav_menu.active {
-    background: #242222;
-    left: 0;
-    opacity: 0.98;
-    transition: all 0.5s ease;
-    z-index: 1;
-  }
+    .nav_menu.active {
+      background: var(--nav-background);
+      left: 0;
+      opacity: 0.98;
+      transition: all 0.5s ease;
+      z-index: 1;
+    }
 
   .nav_links {
     text-align: center;
@@ -126,11 +136,11 @@
     display: table;
   }
 
-  .nav_links:hover {
-    background-color: #fff;
-    color: #242424;
-    border-radius: 0;
-  }
+    .nav_links:hover {
+      background-color: var(--text);
+      color: var(--surface);
+      border-radius: 0;
+    }
 
   .navbar_logo {
     position: absolute;
@@ -159,24 +169,24 @@
     font-size: 2rem;
   }
 
-  .nav_links_mobile {
-    display: block;
-    text-align: center;
-    margin: 2rem auto;
-    border-radius: 4px;
-    width: 80%;
-    text-decoration: none;
-    font-size: 1.5rem;
-    background-color: transparent;
-    color: #fff;
-    padding: 14px 20px;
-    border: 1px solid #fff;
-    transition: all 0.3s ease-out;
-  }
+    .nav_links_mobile {
+      display: block;
+      text-align: center;
+      margin: 2rem auto;
+      border-radius: 4px;
+      width: 80%;
+      text-decoration: none;
+      font-size: 1.5rem;
+      background-color: transparent;
+      color: var(--text);
+      padding: 14px 20px;
+      border: 1px solid var(--text);
+      transition: all 0.3s ease-out;
+    }
 
-  .nav_links_mobile:hover {
-    background: #fff;
-    color: #242424;
-    transition: 250ms;
+    .nav_links_mobile:hover {
+      background: var(--text);
+      color: var(--surface);
+      transition: 250ms;
+    }
   }
-}

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -9,9 +9,11 @@ function Navbar() {
   const [click, setClick] = useState(false);
   const [_button, setButton] = useState(true);
   const [fullTitle, setFullTitle] = useState(true);
+  const [darkMode, setDarkMode] = useState(false);
 
   const handleClick = () => setClick(!click);
   const closeMobileMenu = () => setClick(false);
+  const toggleTheme = () => setDarkMode((prev) => !prev);
 
   const showButton = () => {
     if (typeof window !== 'undefined' && window.innerWidth <= 960) {
@@ -36,11 +38,24 @@ function Navbar() {
       showFullTitle();
     };
 
-    handleResize(); 
+    handleResize();
 
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []); 
+  }, []);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+      setDarkMode(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+    document.body.classList.toggle('light', !darkMode);
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+  }, [darkMode]);
 
   return (
     <>
@@ -59,6 +74,9 @@ function Navbar() {
               className={styles.menu_icon_img}
             />
           </div>
+          <button className={styles.theme_toggle} onClick={toggleTheme} aria-label="Toggle theme">
+            {darkMode ? '🌙' : '☀️'}
+          </button>
           <ul className={`${styles.nav_menu} ${click ? styles.active : ""}`}>
             <li className={styles.nav_item}>
               <Link href="/" className={styles.nav_links} onClick={closeMobileMenu}>


### PR DESCRIPTION
## Summary
- add light and dark theme via CSS variables
- allow toggling theme from navbar
- update footer and navbar styles to respect theme

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895324acd4883238a87c42600b4b72e